### PR TITLE
Fixed hard coded bson module location

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@
  * MIT Licensed
  */
 
-var mongoose = require('mongoose');
 var BinaryParser = require('bson').BinaryParser;
 
 function timestampsPlugin(schema, options) {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     , "url": "git://github.com/drudge/mongoose-timestamp"
     }
   , "dependencies": {
-      "mongoose": ">= 3.0",
       "bson": "0.2.2"
     }
   , "devDependencies": {
-      "should": ">= 0.2.1"
+      "mongoose": ">= 3.0"
+    , "should": ">= 0.2.1"
     , "mocha": ">= 0.13.0"
     }
   , "scripts": {


### PR DESCRIPTION
The code currently loads bson from 'mongoose/node_modules/mongodb/node_modules/bson' which assumes that mongoose is installed in mongoose-timestamp's node_modules directory, and that mongodb is installed under mongoose's node_modules directory.  Better to set bson as a dependency and load it directly, since those two things are not always true.

Also, mongoose is really not a dependency at all.  You were just loading it to get access to bson.  You only need it for tests.
