### PR TITLE
Add support for mongoid dafault timestamp names by flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,33 +6,40 @@
  */
 
 function timestampsPlugin(schema, options) {
+  var updatedAt = 'updatedAt';
+  var createdAt = 'createdAt';
+  if (typeof options === 'object') {
+    if (options.mongoid_comp === true) {
+      updatedAt = 'updated_at';
+      createdAt = 'created_at';
+    }
+  }
+
+  var dataObj = {};
+  dataObj[updatedAt] = Date;
   if (schema.path('_id')) {
-    schema.add({
-      updatedAt: Date
-    });
-    schema.virtual('createdAt')
+    schema.add(dataObj);
+    schema.virtual(createdAt)
       .get( function () {
-        if (this._createdAt) return this._createdAt;
-        return this._createdAt = this._id.getTimestamp();
+        if (this["_" + createdAt]) return this["_" + createdAt];
+        return this["_" + createdAt] = this._id.getTimestamp();
       });
     schema.pre('save', function (next) {
       if (this.isNew) {
-        this.updatedAt = this.createdAt;
+        this[updatedAt] = this[createdAt];
       } else {
-        this.updatedAt = new Date;
+        this[updatedAt] = new Date;
       }
       next();
     });
   } else {
-    schema.add({
-        createdAt: Date
-      , updatedAt: Date
-    });
+    dataObj[createdAt] = Date;
+    schema.add(dataObj);
     schema.pre('save', function (next) {
-      if (!this.createdAt) {
-        this.createdAt = this.updatedAt = new Date;
+      if (!this[createdAt]) {
+        this[createdAt] = this[updatedAt] = new Date;
       } else {
-        this.updatedAt = new Date;
+        this[updatedAt] = new Date;
       }
       next();
     });


### PR DESCRIPTION
For those who use mongo side by sise with ruby code written using mongoid the incompatible var names are problem.
Documented here: http://mongoid.org/en/mongoid/docs/extras.html#timestamps
mongoid uses `created_at` and `updated_at`.
this add on a flag in options, that if `mongoid_comp === true` so this var names are compatible with mongoid defaults.
