### PR TITLE
Select createdAt and updatedAt by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function timestampsPlugin(schema, options) {
   }
 
   var dataObj = {};
-  dataObj[updatedAt] = updatedAtType;
+  dataObj[updatedAt] = { type: updatedAtType, select: true };
   if (schema.path(createdAt)) {
     schema.add(dataObj);
     schema.virtual(createdAt)
@@ -44,7 +44,7 @@ function timestampsPlugin(schema, options) {
       next();
     });
   } else {
-    dataObj[createdAt] = createdAtType;
+    dataObj[createdAt] = { type: createdAtType, select: true };
     schema.add(dataObj);
     schema.pre('save', function (next) {
       if (!this[createdAt]) {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -41,4 +41,19 @@ describe('timestamps', function() {
       }, 1000);
     });
   })
+
+  it('should not update createdAt upon updating with selection', function(done) {
+    TimeCop.findOne({email: 'jeanclaude@vandamme.com'}, function (err, found) {
+      var createdAt = found.createdAt;
+      TimeCop.findOne({email: 'jeanclaude@vandamme.com'}).select('email').exec(function (err, found) {
+        found.email = 'brian@brian.com';
+        setTimeout( function () {
+          found.save( function (err, updated) {
+            createdAt.should.eql(updated.createdAt);
+            done();
+          });
+        }, 1000);
+      });
+    });
+  })
 })


### PR DESCRIPTION
Right now, updating a document after doing a find with certain fields selected will cause createdAt to be modified. This change makes the createdAt and updatedAt fields selected by default.