### PR TITLE
ignorePaths option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ mongoose.plugin(timestamps,  {
   createdAt: 'created_at', 
   updatedAt: 'updated_at'
 });
+```
 
 You can also ignore some properties modifications by passing their paths (if no other property is modified, the updatedAt will not be updated):
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ mongoose.plugin(timestamps,  {
   createdAt: 'created_at', 
   updatedAt: 'updated_at'
 });
+
+You can also ignore some properties modifications by passing their paths (if no other property is modified, the updatedAt will not be updated):
+
+```javascript
+mongoose.plugin(timestamps,  {
+  ignorePaths: [ 'lastSeenAt' ]
+});
 ```
 
 Any model's updatedAt attribute can be updated to the current time using `touch()`.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "mongoose-timestamp",
   "description": "Mongoose plugin that adds createdAt and updatedAt auto-assigned date properties",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Nicholas Penree <nick@penree.com>",
+  "contributors": [
+    "Lubert Theo <theo.lubert@gmail.com>"
+  ],
   "keywords": [
     "mongodb",
     "mongoose",


### PR DESCRIPTION
It can be useful to ignore internal properties modification (ex: lastSeenAt) when it is not relevant, if not wrong, to update "updatedAt".