### PR TITLE
Do not override createdAt when it is not selected

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,12 +43,12 @@ function timestampsPlugin(schema, options) {
 	    }
 	    next();
 	});
-	
+
     } else {
 	dataObj[createdAt] = createdAtType;
 	schema.add(dataObj);
 	schema.pre('save', function (next) {
-	    if (!this[createdAt]) {
+	    if (this.isSelected(createdAt) && !this[createdAt]) {
 		this[createdAt] = this[updatedAt] = new Date;
 	    } else if (this.isModified()) {
 		this[updatedAt] = new Date;

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -43,6 +43,17 @@ describe('timestamps', function() {
     });
   })
 
+  it('should not set a new createdAt if the field is not selected', function(done) {
+    TimeCop.findOne({email: 'jeanclaude@vandamme.com'}, {createdAt: false}, function (err, found) {
+      found.email = 'chuck@norris.com';
+      should(found.createdAt).equal(undefined);
+      found.save( function (err, updated) {
+        should(updated.createdAt).equal(undefined);
+        done();
+      });
+    });
+  })
+
   after(function() {
       mongoose.close();
   });


### PR DESCRIPTION
This fixes this worrisome issue:

```js
return Model
    .findById('xxx')
    .select({
        _id: true
    })
    .execAsync();
    .then(function (model) {
        return model.saveAsync()
    })
    .then(function (model) {
        // createdAt is now overridden :(
    });
```